### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Yarn Loom is a Visual Studio Code extension for editing [yarn files](https://yar
       - [Quick tag search](#quick-tag-search)
     - [Switching between the graph editor and a text editor](#switching-between-the-graph-editor-and-a-text-editor)
     - [Theme support](#theme-support)
+  - [Keyboard Shortcuts](#keyboard-shortcuts)
   - [Special Thanks](#special-thanks)
 
 ## Installing
@@ -170,6 +171,13 @@ If there is a theme where something doesn't look right or is unreadable, please 
   <summary>Expand for demo of switching themes</summary>
   <img src="./images/theme-change.gif" alt="Demo of switching themes in Visual Studio Code" />
 </details>
+
+## Keyboard Shortcuts
+
+| Shortcut                        | Description         |
+| ------------------------------- | ------------------- |
+| <kbd>Ctrl</kbd> + <kbd>F</kbd>  | Focus on search bar |
+| <kbd>Shift</kbd> + <kbd>+</kbd> | Add new node        |
 
 ## Special Thanks
 

--- a/loom-editor/package-lock.json
+++ b/loom-editor/package-lock.json
@@ -6455,6 +6455,11 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
+    "hotkeys-js": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.1.tgz",
+      "integrity": "sha512-YlhVQtyG9f1b7GhtzdhR0Pl+cImD1ZrKI6zYUa7QLd0zuThiL7RzZ+ANJyy7z+kmcCpNYBf5PjBa3CjiQ5PFpw=="
+    },
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -10784,6 +10789,14 @@
       "version": "6.0.7",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
+    },
+    "react-hotkeys-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-2.2.2.tgz",
+      "integrity": "sha512-5XBGCSleJZ7AzQ+wCoFeJj/myByIzqgR3D97xRNEQsGOsFvXLp4V8rbDbHceTqGq7WDjQmX96zegViz8U5CwMQ==",
+      "requires": {
+        "hotkeys-js": "3.8.1"
+      }
     },
     "react-is": {
       "version": "16.13.1",

--- a/loom-editor/package.json
+++ b/loom-editor/package.json
@@ -7,6 +7,7 @@
     "d3": "^5.16.0",
     "loom-common": "file:../loom-common/out",
     "react-d3-graph": "^2.5.0",
+    "react-hotkeys-hook": "^2.2.2",
     "react-scripts": "3.4.1",
     "typesafe-actions": "^5.1.0"
   },

--- a/loom-editor/src/components/App.tsx
+++ b/loom-editor/src/components/App.tsx
@@ -1,21 +1,28 @@
 /** @jsx jsx */
 import { jsx, css } from "@emotion/core";
 import { FunctionComponent } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 
 import "./App.css";
 import NodeGraph from "./NodeGraph";
 import NodeSearch from "./NodeSearch";
+import { createNewNode } from "loom-common/EditorActions";
 
 const appStyle = css`
   width: 100%;
   height: 100%;
 `;
 
-const App: FunctionComponent = () => (
-  <div css={appStyle}>
-    <NodeSearch />
-    <NodeGraph />
-  </div>
-);
+const App: FunctionComponent = () => {
+  // shift and plus key add a new node (note that = is used since shift modifies it to be plus)
+  useHotkeys("shift+=", () => window.vsCodeApi.postMessage(createNewNode()));
+
+  return (
+    <div css={appStyle}>
+      <NodeSearch />
+      <NodeGraph />
+    </div>
+  );
+};
 
 export default App;

--- a/loom-editor/src/components/NodeSearch/SearchBox.tsx
+++ b/loom-editor/src/components/NodeSearch/SearchBox.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, css } from "@emotion/core";
 import { FunctionComponent, useRef } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 
 import { ReactComponent as CaseSensitiveIcon } from "../../icons/case-sensitive.svg";
 import { ReactComponent as RegExIcon } from "../../icons/regex.svg";
@@ -105,6 +106,9 @@ const SearchBox: FunctionComponent = () => {
 
   // used to focus back on the input when clicking buttons in this box
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // ctrl+f focuses on the input box
+  useHotkeys("ctrl+f", () => inputRef.current?.focus());
 
   if (!state) {
     return null;

--- a/loom-extension/README.md
+++ b/loom-extension/README.md
@@ -23,6 +23,7 @@ Yarn Loom is a Visual Studio Code extension for editing [yarn files](https://yar
       - [Quick tag search](#quick-tag-search)
     - [Switching between the graph editor and a text editor](#switching-between-the-graph-editor-and-a-text-editor)
     - [Theme support](#theme-support)
+  - [Keyboard Shortcuts](#keyboard-shortcuts)
   - [Special Thanks](#special-thanks)
 
 ## Usage
@@ -161,6 +162,13 @@ If there is a theme where something doesn't look right or is unreadable, please 
   <summary>Expand for demo of switching themes</summary>
   <img src="https://github.com/TranquilMarmot/YarnLoom/raw/main/images/theme-change.gif" alt="Demo of switching themes in Visual Studio Code" />
 </details>
+
+## Keyboard Shortcuts
+
+| Shortcut                        | Description         |
+| ------------------------------- | ------------------- |
+| <kbd>Ctrl</kbd> + <kbd>F</kbd>  | Focus on search bar |
+| <kbd>Shift</kbd> + <kbd>+</kbd> | Add new node        |
 
 ## Special Thanks
 


### PR DESCRIPTION
This adds <kbd>Ctrl</kbd> + <kbd>F</kbd> (focus on search bar) and <kbd>Shift</kbd> + <kbd>+</kbd> (add new node) keyboard shortcuts.

Initially, I had also wanted to add <kbd>Alt</kbd> + <kbd>C</kbd>/<kbd>R</kbd> to enable/disable case sensitivity/regex (along with T/B/G for title/body/tag search) but there's currently no way for the extension webview to grab keys without sending them to the editor (which causes it to open menus in some cases). I also ran into some issues with state management with the `react-hotkeys-hook` hook in doing this 🤔 