### PR TITLE
Bump @types/react-d3-graph to 2.6.0

### DIFF
--- a/loom-editor/src/components/NodeGraph.tsx
+++ b/loom-editor/src/components/NodeGraph.tsx
@@ -162,7 +162,6 @@ const NodeGraph: FunctionComponent = () => {
         onDoubleClickNode={onNodeDoubleClicked}
         onNodePositionChange={onNodePositionChange}
         onClickGraph={() => dispatch(setFocusedNode(undefined))}
-        // @ts-expect-error until react-d3-graph is updated and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46632 is merged
         onZoomChange={(previousZoom, newZoom) =>
           dispatch(setCurrentZoom(newZoom))
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4387,9 +4387,9 @@
       }
     },
     "@types/react-d3-graph": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-d3-graph/-/react-d3-graph-2.3.5.tgz",
-      "integrity": "sha512-aGld20l1fRJ1SSlOWkyHZzxwbLn2BZHurNdCTHxvpwTIrWOPLd/kYlMsWi9jW8nQ4K5R1CO5eXPBkxDvRpF0bQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@types/react-d3-graph/-/react-d3-graph-2.6.0.tgz",
+      "integrity": "sha512-v/J5PBFXVNCgDK1QpPOMQnqHntGK0v85zj/Eue5AgpNZMJBKUnm9970RuSGfreyVob2PktCmW/fkCyUFMMUvxA==",
       "dev": true,
       "requires": {
         "@types/react": "*"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/jest": "^26.0.23",
     "@types/node": "^15.6.0",
     "@types/react": "^16.9.13",
-    "@types/react-d3-graph": "^2.3.5",
+    "@types/react-d3-graph": "^2.6.0",
     "@types/react-dom": "^16.9.13",
     "@types/rimraf": "^3.0.0",
     "@types/vscode": "^1.56.0",


### PR DESCRIPTION
This brings along types for the zoom functionality