### PR TITLE
Using default editor in diff mode

### DIFF
--- a/loom-extension/package.json
+++ b/loom-extension/package.json
@@ -69,6 +69,11 @@
         "priority": "default"
       }
     ],
+    "configurationDefaults": {
+      "workbench.editorAssociations": {
+        "{git,gitlens}:/**/*.{yarn,yarn.txt}": "default"
+      }
+    },
     "languages": [
       {
         "id": "yarnspinner",


### PR DESCRIPTION
Fix https://github.com/TranquilMarmot/YarnLoom/issues/19

`configurationDefaults` with `workbench.editorAssociations` should work fine use in `VS Code 1.86.0`. See:  https://github.com/microsoft/vscode/issues/138525#issuecomment-1847679100